### PR TITLE
Moved the func bar() throws SomeError() test up to the top of the fil…

### DIFF
--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -823,9 +823,9 @@ Parser::parseFunctionSignature(Identifier SimpleName,
   return Status;
 }
 
-void Parser::parseAsyncThrows(
-    SourceLoc existingArrowLoc, SourceLoc &asyncLoc, SourceLoc &throwsLoc, TypeRepr *&throwsType,
-    bool *rethrows) {
+void Parser::parseAsyncThrows(SourceLoc existingArrowLoc, SourceLoc &asyncLoc,
+                              SourceLoc &throwsLoc, TypeRepr *&throwsType,
+                              bool *rethrows) {
   if (shouldParseExperimentalConcurrency() &&
       Tok.isContextualKeyword("async")) {
     asyncLoc = consumeToken();
@@ -851,16 +851,15 @@ void Parser::parseAsyncThrows(
 
     StringRef keyword = Tok.getText();
     throwsLoc = consumeToken();
-    
+
     if (!peekToken().isKeyword()) {
-      BacktrackingScope backtrackingScope(*this);
-      if (peekToken().is(tok::kw_throws)) {
-        ASTContext &Ctx = SF.getASTContext();
-        DiagnosticSuppression SuppressedDiags(Ctx.Diags);
-        backtrackingScope.cancelBacktrack();
-        if (canParseType()) {
-          ParserResult<TypeRepr> result = parseType();
-          throwsType = result.getPtrOrNull();
+      if (canParseSimpleTypeIdentifier()) {
+        BacktrackingScope backtrack(*this);
+        DiagnosticSuppression SuppressedDiags(Diags);
+        ParserResult<TypeRepr> result = parseType();
+        throwsType = result.getPtrOrNull();
+        if (throwsType) {
+          backtrack.cancelBacktrack();
         }
       }
     }

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -436,19 +436,6 @@ ParserResult<TypeRepr> Parser::parseType(Diag<> MessageID,
         .fixItReplace(Tok.getLoc(), "throws");
     }
     throwsLoc = consumeToken();
-    // The next token is not a keyword
-    if (!peekToken().isKeyword()) {
-      BacktrackingScope backtrackingScope(*this);
-      if (peekToken().is(tok::kw_throws)) {
-        ASTContext &Ctx = SF.getASTContext();
-        DiagnosticSuppression SuppressedDiags(Ctx.Diags);
-        backtrackingScope.cancelBacktrack();
-        if (canParseType()) {
-          ParserResult<TypeRepr> result = parseType();
-          throwsType = result.getPtrOrNull();
-        }
-      }
-    }
 
     // 'async' must preceed 'throws'; accept this but complain.
     if (shouldParseExperimentalConcurrency() &&

--- a/test/Parse/errors.swift
+++ b/test/Parse/errors.swift
@@ -1,5 +1,9 @@
 // RUN: %target-typecheck-verify-swift
 
+struct SomeError: Error {}
+func bar() throws SomeError {}
+
+
 enum MSV : Error {
   case Foo, Bar, Baz
   case CarriesInt(Int)
@@ -41,10 +45,6 @@ func one() {
   }
   
   func foo() throws {}
-
-  struct SomeError: Error {}
-
-  func bar() throws SomeError {}
   
   do {
 #if false


### PR DESCRIPTION
<!-- What's in this pull request? -->
I made some changes over the morning (my time, I am on USA Mountain time. 

It is possible that the `canParseType()` test is too broad and that it is parsing too much stuff. I made it
weaker to just use `canParseSimpleTypeIdentifier`. Also I took out the test in `ParseType.cpp::ParseType`.  
That test was recursing, but I don't think it needed to. 

Does it make sense to create `parseThrowsClause()` and possibly `parseTypeIdentifier()` methods, to match the grammar? That might simplify some of this. The parsing code does not follow the grammar that closely but it is probably good to try. 

Some of the tests fail with this commit still--`errors.swift` succeeds with a type after `throws` but fails later on because it should throw some other errors that are now confused. A few of the others do as well:

```
Failing Tests (5):
    Swift(macosx-x86_64) :: Parse/async.swift
    Swift(macosx-x86_64) :: Parse/errors.swift
    Swift(macosx-x86_64) :: Parse/type_expr.swift
    Swift(macosx-x86_64) :: Syntax/Parser/tree.swift
    Swift(macosx-x86_64) :: incrParse/incrementalTransfer.swift
```

mostly on things that you would expect, like the AST having a different shape. That should be fixable. 

You don't have to merge this, but you can see what I have been working on here. 

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
