### PR TITLE
Added parsing of 'throws (Type)' syntax.

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -732,6 +732,8 @@ ERROR(async_or_throws_in_wrong_position,none,
       (unsigned))
 ERROR(expected_parenthesized_type_after_throws,none,
       "expected a parenthesized type after 'throws'",())
+ERROR(expected_rparen_thrown_type,none,
+      "expected ')' at end of thrown type",())
 ERROR(throw_in_function_type,none,
       "expected throwing specifier; did you mean 'throws'?", ())
 ERROR(expected_type_before_arrow,none,

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -730,6 +730,8 @@ ERROR(rethrowing_function_type,none,
 ERROR(async_or_throws_in_wrong_position,none,
       "%select{'throws'|'rethrows'|'async'}0 may only occur before '->'",
       (unsigned))
+ERROR(expected_parenthesized_type_after_throws,none,
+      "expected a parenthesized type after 'throws'",())
 ERROR(throw_in_function_type,none,
       "expected throwing specifier; did you mean 'throws'?", ())
 ERROR(expected_type_before_arrow,none,

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1377,6 +1377,8 @@ public:
   void parseAsyncThrows(
       SourceLoc existingArrowLoc, SourceLoc &asyncLoc, SourceLoc &throwsLoc, TypeRepr *&throwsType,
       bool *rethrows);
+  
+  ParserResult<TypeRepr> parseThrowsType();
 
   //===--------------------------------------------------------------------===//
   // Pattern Parsing

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1175,6 +1175,11 @@ public:
   ParserResult<TypeRepr> parseType(Diag<> MessageID,
                                    bool HandleCodeCompletion = true,
                                    bool IsSILFuncDecl = false);
+  
+  ParserResult<TypeRepr>
+    parseTypeNotAllowingFunctionType(Diag<> MessageID,
+                                     bool HandleCodeCompletion = true,
+                                     bool IsSILFuncDecl = false);
 
   ParserResult<TypeRepr>
     parseTypeSimpleOrComposition(Diag<> MessageID,

--- a/test/Parse/errors.swift
+++ b/test/Parse/errors.swift
@@ -33,6 +33,23 @@ func missingClosingParenAmbiguous2() throws ((Int) -> () -> Int {}
 // expected-error {{expected ')' at end of thrown type}}
 // expected-note {{to match this opening '('}}
 
+var functionTypeWithThrownType: (Int) throws (SomeError) -> Int
+
+var typeWithThrownType: (Int) throws (SomeError)
+// expected-error @-1 {{consecutive statements on a line must be separated by ';'}}
+// expected-error @-2 {{expected expression}}
+
+var functionTypeMissingClosingParen: (Int) throws (SomeError -> Int
+// expected-error {{expected ')' at end of thrown type}}
+// expected-note {{to match this opening '('}}
+
+var functionTypeMissingThrownType: (Int) throws () -> Int // expected-error {{expected a parenthesized type after 'throws'}} {{50-50- <#type#>}}
+
+var functionTypeMissingClosingParenAndType: (Int) throws ( -> Int
+// expected-error @-1 {{expected a parenthesized type after 'throws'}} {{59-59- <#type#>}}
+// expected-error @-2 {{expected ')' at end of thrown type}}
+// expected-note {{to match this opening '('}}
+
 
 enum MSV : Error {
   case Foo, Bar, Baz

--- a/test/Parse/errors.swift
+++ b/test/Parse/errors.swift
@@ -33,6 +33,9 @@ func missingClosingParenAmbiguous2() throws ((Int) -> () -> Int {}
 // expected-error {{expected ')' at end of thrown type}}
 // expected-note {{to match this opening '('}}
 
+func typedRethrows(_ fn: () throws (SomeError) -> ()) rethrows (SomeError) {}
+
+
 var functionTypeWithThrownType: (Int) throws (SomeError) -> Int
 
 var typeWithThrownType: (Int) throws (SomeError)

--- a/test/Parse/errors.swift
+++ b/test/Parse/errors.swift
@@ -2,16 +2,37 @@
 
 struct SomeError: Error {}
 
-func a() throws (SomeError) -> Int {
+func hasThrownType() throws (SomeError) -> Int {
   return 1
 }
 
-protocol P {
-  func b() throws (SomeError) -> Int
-  func d(x: Int) throws
-  mutating func c() throws (SomeError) -> Int
+protocol TestProtocol {
+  func missingClosingParenAndType() throws ( -> Int
+  // expected-error @-1 {{expected a parenthesized type after 'throws'}} {{45-45- <#type#>}}
+  // expected-error @-2 {{expected ')' at end of thrown type}}
+  // expected-note {{to match this opening '('}}
+
+  func noType(x: Int) throws
+
+  mutating func hasThrownType() throws (SomeError) -> Int
   var x : Int {get}
+
+  func missingClosingParen() throws (SomeError
+  // expected-error {{expected ')' at end of thrown type}}
+  // expected-note {{to match this opening '('}}
+  var z: Int { get set }
 }
+
+
+func missingTrownType() throws () {} // expected-error {{expected a parenthesized type after 'throws'}} {{33-33- <#type#>}}
+
+func missingClosingParenAmbiguous1() throws (Int -> () -> Int {}
+// expected-error {{expected ')' at end of thrown type}}
+// expected-note {{to match this opening '('}}
+func missingClosingParenAmbiguous2() throws ((Int) -> () -> Int {}
+// expected-error {{expected ')' at end of thrown type}}
+// expected-note {{to match this opening '('}}
+
 
 enum MSV : Error {
   case Foo, Bar, Baz

--- a/test/Parse/errors.swift
+++ b/test/Parse/errors.swift
@@ -1,5 +1,18 @@
 // RUN: %target-typecheck-verify-swift
 
+struct SomeError: Error {}
+
+func a() throws (SomeError) -> Int {
+  return 1
+}
+
+protocol P {
+  func b() throws (SomeError) -> Int
+  func d(x: Int) throws
+  mutating func c() throws (SomeError) -> Int
+  var x : Int {get}
+}
+
 enum MSV : Error {
   case Foo, Bar, Baz
   case CarriesInt(Int)
@@ -44,9 +57,9 @@ func one() {
 
   struct SomeError: Swift.Error {}
 
-  func bar() throws SomeError {}
+  func bar() throws (SomeError) {}
 
-  func baz() throws SomeError -> Int { return 2; }
+  func baz() throws (SomeError) -> Int { return 2; }
   
   do {
 #if false


### PR DESCRIPTION
New diagnostic if the parsing fails. Logic to parse an optional
parenthesized type identifier after the 'throws' keyword.

This will not compile the standard library right now because it cannot
parse the pattern

  `func f(_ body: (T) throws -> U) rethrows -> U {return try body(t)}`

That pattern is really common in the standard library for things like
`withUnsafeBufferPointer`. I'm not sure what the problem is right now there.
**EDIT: Resolved**