### PR TITLE
Typed throws fix tests

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -730,9 +730,9 @@ ERROR(rethrowing_function_type,none,
 ERROR(async_or_throws_in_wrong_position,none,
       "%select{'throws'|'rethrows'|'async'}0 may only occur before '->'",
       (unsigned))
-ERROR(expected_parenthesized_type_after_throws,none,
+ERROR(expected_parenthesized_type_after_throws,PointsToFirstBadToken,
       "expected a parenthesized type after 'throws'",())
-ERROR(expected_rparen_thrown_type,none,
+ERROR(expected_rparen_thrown_type,PointsToFirstBadToken,
       "expected ')' at end of thrown type",())
 ERROR(throw_in_function_type,none,
       "expected throwing specifier; did you mean 'throws'?", ())

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -895,6 +895,8 @@ ParserResult<TypeRepr> Parser::parseThrowsType() {
     
     // we parse every type (including function types)
     ParserResult<TypeRepr> throwsTypeRepr = parseType(diag::expected_parenthesized_type_after_throws);
+    if (throwsTypeRepr.hasCodeCompletion())
+      return makeParserCodeCompletionResult<TypeRepr>();
     
     // if the closing parenthesis is missing, we backtrack and parse the type
     // again, this time excluding function types
@@ -903,6 +905,8 @@ ParserResult<TypeRepr> Parser::parseThrowsType() {
         backtracking.reset();
         
         throwsTypeRepr = parseTypeNotAllowingFunctionType(diag::expected_parenthesized_type_after_throws);
+        if (throwsTypeRepr.hasCodeCompletion())
+          return makeParserCodeCompletionResult<TypeRepr>();
       }
     }
     
@@ -911,6 +915,13 @@ ParserResult<TypeRepr> Parser::parseThrowsType() {
     
     // Parse the closing ')'.
     SourceLoc rParenLoc;
+//    if (Tok.is(tok::r_paren)) {
+//      parseMatchingToken(tok::r_paren, rParenLoc, diag::expected_rparen_thrown_type, lParenLoc);
+//    } else {
+//      rParenLoc = PreviousLoc;
+//    }
+    
+//    diagnose(rParenLoc, diag::expected_rparen_thrown_type);
     parseMatchingToken(tok::r_paren, rParenLoc, diag::expected_rparen_thrown_type, lParenLoc);
     
     return throwsTypeRepr;

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -895,9 +895,7 @@ ParserResult<TypeRepr> Parser::parseThrowsType() {
     
     // we parse every type (including function types)
     ParserResult<TypeRepr> throwsTypeRepr = parseType(diag::expected_parenthesized_type_after_throws);
-    if (throwsTypeRepr.hasCodeCompletion())
-      return makeParserCodeCompletionResult<TypeRepr>();
-    
+
     // if the closing parenthesis is missing, we backtrack and parse the type
     // again, this time excluding function types
     if (auto typeRepr = throwsTypeRepr.getPtrOrNull()) {
@@ -905,8 +903,6 @@ ParserResult<TypeRepr> Parser::parseThrowsType() {
         backtracking.reset();
         
         throwsTypeRepr = parseTypeNotAllowingFunctionType(diag::expected_parenthesized_type_after_throws);
-        if (throwsTypeRepr.hasCodeCompletion())
-          return makeParserCodeCompletionResult<TypeRepr>();
       }
     }
     
@@ -916,6 +912,9 @@ ParserResult<TypeRepr> Parser::parseThrowsType() {
     // Parse the closing ')'.
     SourceLoc rParenLoc;
     parseMatchingToken(tok::r_paren, rParenLoc, diag::expected_rparen_thrown_type, lParenLoc);
+    
+    if (throwsTypeRepr.hasCodeCompletion())
+      return makeParserCodeCompletionResult<TypeRepr>();
     
     return throwsTypeRepr;
   }

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -915,13 +915,6 @@ ParserResult<TypeRepr> Parser::parseThrowsType() {
     
     // Parse the closing ')'.
     SourceLoc rParenLoc;
-//    if (Tok.is(tok::r_paren)) {
-//      parseMatchingToken(tok::r_paren, rParenLoc, diag::expected_rparen_thrown_type, lParenLoc);
-//    } else {
-//      rParenLoc = PreviousLoc;
-//    }
-    
-//    diagnose(rParenLoc, diag::expected_rparen_thrown_type);
     parseMatchingToken(tok::r_paren, rParenLoc, diag::expected_rparen_thrown_type, lParenLoc);
     
     return throwsTypeRepr;

--- a/test/Parse/errors.swift
+++ b/test/Parse/errors.swift
@@ -3,14 +3,15 @@
 struct SomeError: Error {}
 
 func hasThrownType() throws (SomeError) -> Int {
+  throw SomeError()
   return 1
 }
 
 protocol TestProtocol {
   func missingClosingParenAndType() throws ( -> Int
-  // expected-error @-1 {{expected a parenthesized type after 'throws'}} {{45-45- <#type#>}}
-  // expected-error @-2 {{expected ')' at end of thrown type}}
-  // expected-note {{to match this opening '('}}
+  // expected-error@-1 {{expected a parenthesized type after 'throws'}} {{45-45= <#type#>}}
+  // expected-error@-2 {{expected ')' at end of thrown type}}
+  // expected-note@-3 {{to match this opening '('}}
 
   func noType(x: Int) throws
 
@@ -18,20 +19,20 @@ protocol TestProtocol {
   var x : Int {get}
 
   func missingClosingParen() throws (SomeError
-  // expected-error {{expected ')' at end of thrown type}}
-  // expected-note {{to match this opening '('}}
+  // expected-error@-1 {{expected ')' at end of thrown type}}
+  // expected-note@-2 {{to match this opening '('}}
   var z: Int { get set }
 }
 
 
-func missingTrownType() throws () {} // expected-error {{expected a parenthesized type after 'throws'}} {{33-33- <#type#>}}
+func missingTrownType() throws () {} // expected-error {{expected a parenthesized type after 'throws'}} {{33-33= <#type#>}}
 
 func missingClosingParenAmbiguous1() throws (Int -> () -> Int {}
-// expected-error {{expected ')' at end of thrown type}}
-// expected-note {{to match this opening '('}}
+// expected-error@-1 {{expected ')' at end of thrown type}}
+// expected-note@-2 {{to match this opening '('}}
 func missingClosingParenAmbiguous2() throws ((Int) -> () -> Int {}
-// expected-error {{expected ')' at end of thrown type}}
-// expected-note {{to match this opening '('}}
+// expected-error@-1 {{expected ')' at end of thrown type}}
+// expected-note@-2 {{to match this opening '('}}
 
 func typedRethrows(_ fn: () throws (SomeError) -> ()) rethrows (SomeError) {}
 
@@ -39,19 +40,19 @@ func typedRethrows(_ fn: () throws (SomeError) -> ()) rethrows (SomeError) {}
 var functionTypeWithThrownType: (Int) throws (SomeError) -> Int
 
 var typeWithThrownType: (Int) throws (SomeError)
-// expected-error @-1 {{consecutive statements on a line must be separated by ';'}}
-// expected-error @-2 {{expected expression}}
+// expected-error@-1 {{consecutive statements on a line must be separated by ';'}}
+// expected-error@-2 {{expected expression}}
 
 var functionTypeMissingClosingParen: (Int) throws (SomeError -> Int
-// expected-error {{expected ')' at end of thrown type}}
-// expected-note {{to match this opening '('}}
+// expected-error@-1 {{expected ')' at end of thrown type}}
+// expected-note@-2 {{to match this opening '('}}
 
-var functionTypeMissingThrownType: (Int) throws () -> Int // expected-error {{expected a parenthesized type after 'throws'}} {{50-50- <#type#>}}
+var functionTypeMissingThrownType: (Int) throws () -> Int // expected-error {{expected a parenthesized type after 'throws'}} {{50-50= <#type#>}}
 
 var functionTypeMissingClosingParenAndType: (Int) throws ( -> Int
-// expected-error @-1 {{expected a parenthesized type after 'throws'}} {{59-59- <#type#>}}
-// expected-error @-2 {{expected ')' at end of thrown type}}
-// expected-note {{to match this opening '('}}
+// expected-error@-1 {{expected a parenthesized type after 'throws'}} {{59-59= <#type#>}}
+// expected-error@-2 {{expected ')' at end of thrown type}}
+// expected-note@-3 {{to match this opening '('}}
 
 
 enum MSV : Error {


### PR DESCRIPTION
I have fixed the Parse suite of tests, except for `async-syntax` ones, today I haven't time to check why they're making the frontend crash 😆 

```
********************

Testing Time: 54.53s
********************
Failing Tests (1):
    Swift(macosx-x86_64) :: Parse/async-syntax.swift

  Expected Passes    : 174
  Unsupported Tests  : 1
  Unexpected Failures: 1
```