### PR TITLE
Fix round_trip_parse_gen tests

### DIFF
--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -851,13 +851,14 @@ void Parser::parseAsyncThrows(SourceLoc existingArrowLoc, SourceLoc &asyncLoc,
     StringRef keyword;
     
     keyword = Tok.getText();
-    throwsLoc = consumeToken();
+    if (Tok.is(tok::kw_throws))
+      throwsLoc = consumeToken();
     
     ParserResult<TypeRepr> throwsTypeResult = parseThrowsType();
     
     throwsType = throwsTypeResult.getPtrOrNull();
     
-    if (existingArrowLoc.isValid()) {
+    if (existingArrowLoc.isValid() && throwsLoc.isValid()) {
       diagnose(throwsLoc, diag::async_or_throws_in_wrong_position,
                rethrows ? (*rethrows ? 1 : 0) : 0)
         .fixItRemove(throwsLoc)

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -851,8 +851,7 @@ void Parser::parseAsyncThrows(SourceLoc existingArrowLoc, SourceLoc &asyncLoc,
     StringRef keyword;
     
     keyword = Tok.getText();
-    if (Tok.is(tok::kw_throws))
-      throwsLoc = consumeToken();
+    throwsLoc = consumeToken();
     
     ParserResult<TypeRepr> throwsTypeResult = parseThrowsType();
     

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -505,7 +505,8 @@ ParserResult<TypeRepr> Parser::parseType(Diag<> MessageID,
     // function type
     BacktrackingScope backtrack(*this);
     
-    throwsLoc = consumeToken();
+    if (Tok.is(tok::kw_throws))
+      throwsLoc = consumeToken();
     
     ParserResult<TypeRepr> throwsTypeResult = parseThrowsType();
     

--- a/test/Syntax/Parser/tree.swift.result
+++ b/test/Syntax/Parser/tree.swift.result
@@ -2,7 +2,7 @@
 // RUN: %swift-syntax-parser-test %s -dump-tree > %t.result
 // RUN: diff -u %s.result %t.result
 
-|func| </t6><t105>|test|</t105><NULL/><s110><s108><t88>|(|</t88><s174></s174><t89>|)| </t89></s108><NULL/><NULL/><NULL/></s110><NULL/><s93><t90>|{|</t90><s163><s92><s48><NULL/><t102>
+|func| </t6><t105>|test|</t105><NULL/><s110><s108><t88>|(|</t88><s174></s174><t89>|)| </t89></s108><NULL/><NULL/><NULL/><NULL/></s110><NULL/><s93><t90>|{|</t90><s163><s92><s48><NULL/><t102>
   |"|</t102><s168><s104><t104>|a|</t104></s104><s105><t100>|\|</t100><NULL/><t88>|(|</t88><s165><s97><NULL/><NULL/><s28><t105>|b|</t105><NULL/></s28><NULL/></s97></s165><t101>|)|</t101></s105><s104><t104>|c|</t104></s104></s168><t102>|"|</t102><NULL/></s48><NULL/><NULL/></s92></s163><t91>
 |}|</t91></s93></s13><NULL/><NULL/></s92></s163><t0>
 ||</t0></s118>

--- a/test/incrParse/Outputs/incrementalTransfer.json
+++ b/test/incrParse/Outputs/incrementalTransfer.json
@@ -92,6 +92,7 @@
                     },
                     null,
                     null,
+                    null,
                     null
                   ],
                   "presence": "Present"

--- a/unittests/Syntax/DeclSyntaxTests.cpp
+++ b/unittests/Syntax/DeclSyntaxTests.cpp
@@ -394,9 +394,10 @@ FunctionSignatureSyntax getCannedFunctionSignature() {
                                                                     LParen,
                                                                     Error,
                                                                     RParen);
+  auto TypedThrow = SyntaxFactory::makeParenthesizedExpression(LParen, Error, RParen);
 
   return
-    SyntaxFactory::makeFunctionSignature(Parameter, None, TypedThrows, Return);
+    SyntaxFactory::makeFunctionSignature(Parameter, None, Throws, TypedThrow, Return);
 }
 
 TEST(DeclSyntaxTests, FunctionSignatureMakeAPIs) {
@@ -433,7 +434,7 @@ TEST(DeclSyntaxTests, FunctionSignatureGetAPIs) {
 
   auto Sig = SyntaxFactory::makeFunctionSignature(
     SyntaxFactory::makeParameterClause(LParen, List, RParen),
-    None, Throws,
+    None, Throws, None,
     SyntaxFactory::makeReturnClause(Arrow, Int));
 
   ASSERT_EQ(LParen.getRaw(), Sig.getInput().getLeftParen().getRaw());
@@ -452,8 +453,8 @@ TEST(DeclSyntaxTests, FunctionSignatureGetAPIs) {
   }
 
   ASSERT_EQ(RParen.getRaw(), Sig.getInput().getRightParen().getRaw());
-  ASSERT_EQ(Throws.getRaw(), Sig.getThrowsOrRethrows()->getAs<TokenSyntax>()->getRaw());
-  ASSERT_EQ(Sig.getThrowsOrRethrows()->getAs<TokenSyntax>()->getTokenKind(), tok::kw_throws);
+  ASSERT_EQ(Throws.getRaw(), Sig.getThrowsOrRethrowsKeyword()->getRaw());
+  ASSERT_EQ(Sig.getThrowsOrRethrowsKeyword()->getTokenKind(), tok::kw_throws);
   ASSERT_EQ(Arrow.getRaw(), Sig.getOutput()->getArrow().getRaw());
 
   {
@@ -486,7 +487,7 @@ TEST(DeclSyntaxTests, FunctionSignatureWithAPIs) {
   llvm::raw_svector_ostream OS(Scratch);
   SyntaxFactory::makeBlankFunctionSignature()
     .withInput(Parameter)
-    .withThrowsOrRethrows(Throws)
+    .withThrowsOrRethrowsKeyword(Throws)
     .withOutput(Return)
     .print(OS);
   ASSERT_EQ(OS.str().str(),

--- a/unittests/Syntax/TypeSyntaxTests.cpp
+++ b/unittests/Syntax/TypeSyntaxTests.cpp
@@ -512,6 +512,7 @@ TEST(TypeSyntaxTests, FunctionTypeMakeAPIs) {
                                     RightParen,
                                     Async,
                                     Throws,
+                                    None,
                                     Arrow,
                                     Int)
       .print(OS);
@@ -533,6 +534,8 @@ TEST(TypeSyntaxTests, FunctionTypeMakeAPIs) {
       .withName(y)
       .withColon(Colon)
       .withType(Int);
+    
+    auto TypedThrow = SyntaxFactory::makeParenthesizedExpression(LeftParen, Error, RightParen);
 
     auto TypeList = SyntaxFactory::makeTupleTypeElementList({
       xArg, yArg
@@ -542,6 +545,7 @@ TEST(TypeSyntaxTests, FunctionTypeMakeAPIs) {
                                     RightParen,
                                     None,
                                     Throws,
+                                    None,
                                     Arrow,
                                     Int)
       .print(OS);
@@ -562,6 +566,7 @@ TEST(TypeSyntaxTests, FunctionTypeMakeAPIs) {
       .withName(y)
       .withColon(Colon)
       .withType(Int);
+    auto TypedThrow = SyntaxFactory::makeParenthesizedExpression(LeftParen, Error, RightParen);
 
     auto TypeList = SyntaxFactory::makeTupleTypeElementList({
       xArg, yArg
@@ -570,7 +575,8 @@ TEST(TypeSyntaxTests, FunctionTypeMakeAPIs) {
                                     TypeList,
                                     RightParen,
                                     None,
-                                    TypedThrows,
+                                    Throws,
+                                    TypedThrow,
                                     Arrow,
                                     Int)
       .print(OS);
@@ -588,6 +594,7 @@ TEST(TypeSyntaxTests, FunctionTypeMakeAPIs) {
                                     RightParen,
                                     None,
                                     Rethrows,
+                                    None,
                                     Arrow,
                                     Int).print(OS);
     ASSERT_EQ(OS.str().str(), "(Int, Int) rethrows -> Int");
@@ -596,6 +603,7 @@ TEST(TypeSyntaxTests, FunctionTypeMakeAPIs) {
   {
     SmallString<48> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
+    auto TypedThrow = SyntaxFactory::makeParenthesizedExpression(LeftParen, Error, RightParen);
     auto TypeList = SyntaxFactory::makeTupleTypeElementList({
       IntArg.withTrailingComma(Comma),
       IntArg
@@ -604,7 +612,8 @@ TEST(TypeSyntaxTests, FunctionTypeMakeAPIs) {
                                     TypeList,
                                     RightParen,
                                     None,
-                                    TypedRethrows,
+                                    Rethrows,
+                                    TypedThrow,
                                     Arrow,
                                     Int).print(OS);
     ASSERT_EQ(OS.str().str(), "(Int, Int) rethrows (Error) -> Int");
@@ -617,6 +626,7 @@ TEST(TypeSyntaxTests, FunctionTypeMakeAPIs) {
     SyntaxFactory::makeFunctionType(LeftParen,
                                     TypeList,
                                     RightParen,
+                                    None,
                                     None,
                                     None,
                                     Arrow,
@@ -663,7 +673,7 @@ TEST(TypeSyntaxTests, FunctionTypeWithAPIs) {
       .addArgument(xArg)
       .addArgument(yArg)
       .withRightParen(RightParen)
-      .withThrowsOrRethrows(Throws)
+      .withThrowsOrRethrowsKeyword(Throws)
       .withArrow(Arrow)
       .withReturnType(Int)
       .print(OS);
@@ -682,13 +692,15 @@ TEST(TypeSyntaxTests, FunctionTypeWithAPIs) {
                                                     Int, None, None, Comma);
     auto yArg = SyntaxFactory::makeTupleTypeElement(None, y, None, Colon,
                                                     Int, None, None, None);
+    auto TypedThrow = SyntaxFactory::makeParenthesizedExpression(LeftParen, Error, RightParen);
 
     SyntaxFactory::makeBlankFunctionType()
       .withLeftParen(LeftParen)
       .addArgument(xArg)
       .addArgument(yArg)
       .withRightParen(RightParen)
-      .withThrowsOrRethrows(TypedThrows)
+      .withThrowsOrRethrowsKeyword(Throws)
+      .withThrowsOrRethrowsType(TypedThrow)
       .withArrow(Arrow)
       .withReturnType(Int)
       .print(OS);
@@ -705,7 +717,7 @@ TEST(TypeSyntaxTests, FunctionTypeWithAPIs) {
       .withRightParen(RightParen)
       .addArgument(IntArg.withTrailingComma(Comma))
       .addArgument(IntArg)
-      .withThrowsOrRethrows(Rethrows)
+      .withThrowsOrRethrowsKeyword(Rethrows)
       .withArrow(Arrow)
       .withReturnType(Int)
       .print(OS);
@@ -715,12 +727,15 @@ TEST(TypeSyntaxTests, FunctionTypeWithAPIs) {
   {
     SmallString<48> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
+    auto TypedThrow = SyntaxFactory::makeParenthesizedExpression(LeftParen, Error, RightParen);
+    
     SyntaxFactory::makeBlankFunctionType()
       .withLeftParen(LeftParen)
       .withRightParen(RightParen)
       .addArgument(IntArg.withTrailingComma(Comma))
       .addArgument(IntArg)
-      .withThrowsOrRethrows(TypedRethrows)
+      .withThrowsOrRethrowsKeyword(Rethrows)
+      .withThrowsOrRethrowsType(TypedThrow)
       .withArrow(Arrow)
       .withReturnType(Int)
       .print(OS);
@@ -773,12 +788,13 @@ TEST(TypeSyntaxTests, FunctionTypeBuilderAPIs) {
                                                     Int, None, None, Comma);
     auto yArg = SyntaxFactory::makeTupleTypeElement(None, y, None, Colon,
                                                     Int, None, None, None);
+    auto TypedThrow = SyntaxFactory::makeParenthesizedExpression(LeftParen, Error, RightParen);
 
     Builder.useLeftParen(LeftParen)
       .useRightParen(RightParen)
       .addArgument(xArg)
       .addArgument(yArg)
-      .useThrowsOrRethrows(Throws)
+      .useThrowsOrRethrowsKeyword(Throws)
       .useArrow(Arrow)
       .useReturnType(Int);
 
@@ -797,12 +813,14 @@ TEST(TypeSyntaxTests, FunctionTypeBuilderAPIs) {
                                                     Int, None, None, Comma);
     auto yArg = SyntaxFactory::makeTupleTypeElement(None, y, None, Colon,
                                                     Int, None, None, None);
+    auto TypedThrow = SyntaxFactory::makeParenthesizedExpression(LeftParen, Error, RightParen);
 
     Builder.useLeftParen(LeftParen)
       .useRightParen(RightParen)
       .addArgument(xArg)
       .addArgument(yArg)
-      .useThrowsOrRethrows(TypedThrows)
+      .useThrowsOrRethrowsKeyword(Throws)
+      .useThrowsOrRethrowsType(TypedThrow)
       .useArrow(Arrow)
       .useReturnType(Int);
 
@@ -820,7 +838,7 @@ TEST(TypeSyntaxTests, FunctionTypeBuilderAPIs) {
       .useRightParen(RightParen)
       .addArgument(IntArg.withTrailingComma(Comma))
       .addArgument(IntArg)
-      .useThrowsOrRethrows(Rethrows)
+      .useThrowsOrRethrowsKeyword(Rethrows)
       .useArrow(Arrow)
       .useReturnType(Int);
 

--- a/utils/gyb_syntax_support/DeclNodes.py
+++ b/utils/gyb_syntax_support/DeclNodes.py
@@ -83,6 +83,14 @@ DECL_NODES = [
              Child('RightParen', kind='RightParenToken'),
           ]),
 
+    Node('ParenthesizedExpression', kind='Syntax',
+        children=[
+            Child('LeftParen', kind='LeftParenToken'),
+            Child('ThrowsType', kind='Type'),
+            Child('RightParen', kind='RightParenToken'),
+        ]
+    ),
+
     # function-signature ->
     #   '(' parameter-list? ')' async? ('throws'|'throws' '(' type ')')? ('->' type)?
     Node('FunctionSignature', kind='Syntax',
@@ -91,16 +99,12 @@ DECL_NODES = [
              Child('AsyncKeyword', kind='IdentifierToken',
                    classification='Keyword',
                    text_choices=['async'], is_optional=True),
-             Child('ThrowsOrRethrows', kind='Syntax',
-                   is_optional=True,
-                   node_choices=[
-                       Child('ThrowsOrRethrowsKeyword', kind='Token',
-                             token_choices=[
-                                 'ThrowsToken',
-                                 'RethrowsToken',
-                             ]),
-                       Child('TypedThrowsOrRethrows', kind='TypedThrowsOrRethrowsClause'),
-                   ]),
+             Child('ThrowsOrRethrowsKeyword', kind='Token', is_optional=True,
+                    token_choices=[
+                        'ThrowsToken',
+                        'RethrowsToken',
+                    ]),
+             Child('ThrowsOrRethrowsType', kind='ParenthesizedExpression', is_optional=True),
              Child('Output', kind='ReturnClause', is_optional=True),
          ]),
 
@@ -438,16 +442,12 @@ DECL_NODES = [
              Child('GenericParameterClause', kind='GenericParameterClause',
                    is_optional=True),
              Child('Parameters', kind='ParameterClause'),
-             Child('ThrowsOrRethrows', kind='Syntax',
-                   is_optional=True,
-                   node_choices=[
-                       Child('ThrowsOrRethrowsKeyword', kind='Token',
-                             token_choices=[
-                                 'ThrowsToken',
-                                 'RethrowsToken',
-                             ]),
-                       Child('TypedThrowsOrRethrows', kind='TypedThrowsOrRethrowsClause'),
-                   ]),
+             Child('ThrowsOrRethrowsKeyword', kind='Token', is_optional=True,
+                    token_choices=[
+                        'ThrowsToken',
+                        'RethrowsToken',
+                    ]),
+             Child('ThrowsOrRethrowsType', kind='ParenthesizedExpression', is_optional=True),
              Child('GenericWhereClause', kind='GenericWhereClause',
                    is_optional=True),
              # the body is not necessary inside a protocol definition

--- a/utils/gyb_syntax_support/NodeSerializationCodes.py
+++ b/utils/gyb_syntax_support/NodeSerializationCodes.py
@@ -254,7 +254,7 @@ SYNTAX_NODE_SERIALIZATION_CODES = {
     'PoundFileIDExpr': 247,
     # relocated: 'AwaitExpr': 248,
     # relocated: 'TypedThrowsClause': 249,
-    # relocated: 'TypedThrowsOrRethrowsClause': 250,
+    'ParenthesizedExpression': 251,
 }
 
 

--- a/utils/gyb_syntax_support/TypeNodes.py
+++ b/utils/gyb_syntax_support/TypeNodes.py
@@ -169,16 +169,13 @@ TYPE_NODES = [
              Child('AsyncKeyword', kind='IdentifierToken',
                    classification='Keyword',
                    text_choices=['async'], is_optional=True),
-             Child('ThrowsOrRethrows', kind='Syntax',
-                   is_optional=True,
-                   node_choices=[
-                       Child('ThrowsOrRethrowsKeyword', kind='Token',
-                             token_choices=[
-                                 'ThrowsToken',
-                                 'RethrowsToken',
-                             ]),
-                       Child('TypedThrowsOrRethrows', kind='TypedThrowsOrRethrowsClause'),
-                   ]),
+             Child('ThrowsOrRethrowsKeyword', kind='Token', is_optional=True,
+                    token_choices=[
+                        'ThrowsToken',
+                        'RethrowsToken',
+                        'ThrowToken',
+                    ]),
+             Child('ThrowsOrRethrowsType', kind='ParenthesizedExpression', is_optional=True),
              Child('Arrow', kind='ArrowToken'),
              Child('ReturnType', kind='Type'),
          ]),


### PR DESCRIPTION
~Too late to finish it https://www.diffchecker.com/SDnOYloi Tomorrow I'll end it.~

> ~Note: the right one is the correct one. Left-side, ours.~

So I went for the simple syntax tree (changes might be made in the future if needed) tests are running now, I'll post the report when they're ready.

```
********************

Testing Time: 3493.74s
********************
Failing Tests (2):
    Swift(macosx-x86_64) :: SILGen/addressors.swift
    Swift(macosx-x86_64) :: SILOptimizer/prespecialize.swift

  Expected Passes    : 6654
  Expected Failures  : 21
  Unsupported Tests  : 170
  Unexpected Failures: 2

4 warning(s) in tests
```

```
stdlib: compiling
```